### PR TITLE
optimize ifft

### DIFF
--- a/halo2_proofs/CHANGELOG.md
+++ b/halo2_proofs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to Rust's notion of
     any verification failures before panicking.
 - `halo2_proofs::plonk::Constraints` helper, for constructing a gate from a set
   of constraints with a common selector.
+- `halo2_proofs::arithmetic::best_ifft`
 
 ### Changed
 - `halo2_proofs::dev`:

--- a/halo2_proofs/benches/fft.rs
+++ b/halo2_proofs/benches/fft.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate criterion;
 
-use crate::arithmetic::best_fft;
+use crate::arithmetic::{best_fft, best_ifft};
 use crate::pasta::Fp;
 use group::ff::Field;
 use halo2_proofs::*;
@@ -10,9 +10,9 @@ use criterion::{BenchmarkId, Criterion};
 use rand_core::OsRng;
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let mut group = c.benchmark_group("fft");
+    let mut fft_group = c.benchmark_group("fft");
     for k in 3..19 {
-        group.bench_function(BenchmarkId::new("k", k), |b| {
+        fft_group.bench_function(BenchmarkId::new("k", k), |b| {
             let mut a = (0..(1 << k)).map(|_| Fp::random(OsRng)).collect::<Vec<_>>();
             let omega = Fp::random(OsRng); // would be weird if this mattered
             b.iter(|| {
@@ -20,6 +20,20 @@ fn criterion_benchmark(c: &mut Criterion) {
             });
         });
     }
+    fft_group.finish();
+
+    let mut ifft_group = c.benchmark_group("ifft");
+    for k in 3..19 {
+        ifft_group.bench_function(BenchmarkId::new("k", k), |b| {
+            let mut a = (0..(1 << k)).map(|_| Fp::random(OsRng)).collect::<Vec<_>>();
+            let omega_inv = Fp::random(OsRng); // would be weird if this mattered
+            let divisor = Fp::random(OsRng); // would be weird if this mattered
+            b.iter(|| {
+                best_ifft(&mut a, omega_inv, k as u32, divisor);
+            });
+        });
+    }
+    ifft_group.finish();
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/halo2_proofs/src/arithmetic.rs
+++ b/halo2_proofs/src/arithmetic.rs
@@ -1,7 +1,7 @@
 //! This module provides common utilities, traits and structures for group,
 //! field and polynomial arithmetic.
 
-use super::multicore;
+use super::multicore::{self, log_threads};
 pub use ff::Field;
 use group::{
     ff::{BatchInvert, PrimeField},
@@ -166,29 +166,11 @@ pub fn best_multiexp<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Cu
 /// distinct powers of $\omega$. This transformation is invertible by providing
 /// $\omega^{-1}$ in place of $\omega$ and dividing each resulting field element
 /// by $n$.
-///
-/// This will use multithreading if beneficial.
 pub fn best_fft<G: Group>(a: &mut [G], omega: G::Scalar, log_n: u32) {
-    fn bitreverse(mut n: usize, l: usize) -> usize {
-        let mut r = 0;
-        for _ in 0..l {
-            r = (r << 1) | (n & 1);
-            n >>= 1;
-        }
-        r
-    }
-
-    let threads = multicore::current_num_threads();
-    let log_threads = log2_floor(threads);
     let n = a.len() as usize;
     assert_eq!(n, 1 << log_n);
 
-    for k in 0..n {
-        let rk = bitreverse(k, log_n as usize);
-        if k < rk {
-            a.swap(rk, k);
-        }
-    }
+    swap_bit_reverse(a, n, log_n);
 
     // precompute twiddle factors
     let twiddles: Vec<_> = (0..(n / 2) as usize)
@@ -199,47 +181,40 @@ pub fn best_fft<G: Group>(a: &mut [G], omega: G::Scalar, log_n: u32) {
         })
         .collect();
 
-    if log_n <= log_threads {
-        let mut chunk = 2_usize;
-        let mut twiddle_chunk = (n / 2) as usize;
-        for _ in 0..log_n {
-            a.chunks_mut(chunk).for_each(|coeffs| {
-                let (left, right) = coeffs.split_at_mut(chunk / 2);
-
-                // case when twiddle factor is one
-                let (a, left) = left.split_at_mut(1);
-                let (b, right) = right.split_at_mut(1);
-                let t = b[0];
-                b[0] = a[0];
-                a[0].group_add(&t);
-                b[0].group_sub(&t);
-
-                left.iter_mut()
-                    .zip(right.iter_mut())
-                    .enumerate()
-                    .for_each(|(i, (a, b))| {
-                        let mut t = *b;
-                        t.group_scale(&twiddles[(i + 1) * twiddle_chunk]);
-                        *b = *a;
-                        a.group_add(&t);
-                        b.group_sub(&t);
-                    });
-            });
-            chunk *= 2;
-            twiddle_chunk /= 2;
-        }
+    if log_n <= log_threads() {
+        serial_fft(a, n, log_n, &twiddles)
     } else {
-        recursive_butterfly_arithmetic(a, n, 1, &twiddles)
+        parallel_fft(a, n, 1, &twiddles)
+    }
+}
+
+/// Performs a radix-$2$ inverse Fast-Fourier Transformation (FFT)
+pub fn best_ifft<G: Group>(a: &mut [G], omega_inv: G::Scalar, log_n: u32, divisor: G::Scalar) {
+    best_fft(a, omega_inv, log_n);
+    parallelize(a, |a, _| {
+        for a in a {
+            // Finish iFFT
+            a.group_scale(&divisor);
+        }
+    });
+}
+
+/// This performs serial butterfly arithmetic
+pub(crate) fn serial_fft<G: Group>(a: &mut [G], n: usize, log_n: u32, twiddles: &[G::Scalar]) {
+    let mut chunk = 2_usize;
+    let mut twiddle_chunk = (n / 2) as usize;
+    for _ in 0..log_n {
+        a.chunks_mut(chunk).for_each(|coeffs| {
+            let (left, right) = coeffs.split_at_mut(chunk / 2);
+            butterfly_arithmetic(left, right, twiddle_chunk, twiddles)
+        });
+        chunk *= 2;
+        twiddle_chunk /= 2;
     }
 }
 
 /// This perform recursive butterfly arithmetic
-pub fn recursive_butterfly_arithmetic<G: Group>(
-    a: &mut [G],
-    n: usize,
-    twiddle_chunk: usize,
-    twiddles: &[G::Scalar],
-) {
+pub fn parallel_fft<G: Group>(a: &mut [G], n: usize, twiddle_chunk: usize, twiddles: &[G::Scalar]) {
     if n == 2 {
         let t = a[1];
         a[1] = a[0];
@@ -248,28 +223,11 @@ pub fn recursive_butterfly_arithmetic<G: Group>(
     } else {
         let (left, right) = a.split_at_mut(n / 2);
         rayon::join(
-            || recursive_butterfly_arithmetic(left, n / 2, twiddle_chunk * 2, twiddles),
-            || recursive_butterfly_arithmetic(right, n / 2, twiddle_chunk * 2, twiddles),
+            || parallel_fft(left, n / 2, twiddle_chunk * 2, twiddles),
+            || parallel_fft(right, n / 2, twiddle_chunk * 2, twiddles),
         );
 
-        // case when twiddle factor is one
-        let (a, left) = left.split_at_mut(1);
-        let (b, right) = right.split_at_mut(1);
-        let t = b[0];
-        b[0] = a[0];
-        a[0].group_add(&t);
-        b[0].group_sub(&t);
-
-        left.iter_mut()
-            .zip(right.iter_mut())
-            .enumerate()
-            .for_each(|(i, (a, b))| {
-                let mut t = *b;
-                t.group_scale(&twiddles[(i + 1) * twiddle_chunk]);
-                *b = *a;
-                a.group_add(&t);
-                b.group_sub(&t);
-            });
+        butterfly_arithmetic(left, right, twiddle_chunk, twiddles)
     }
 }
 
@@ -340,16 +298,42 @@ pub fn parallelize<T: Send, F: Fn(&mut [T], usize) + Send + Sync + Clone>(v: &mu
     });
 }
 
-fn log2_floor(num: usize) -> u32 {
-    assert!(num > 0);
-
-    let mut pow = 0;
-
-    while (1 << (pow + 1)) <= num {
-        pow += 1;
+/// This performs bit reverse permutation over `[G]`
+fn swap_bit_reverse<G: Group>(a: &mut [G], n: usize, log_n: u32) {
+    // sort by bit reverse
+    let diff = 64 - log_n;
+    for i in 0..n as u64 {
+        let ri = i.reverse_bits() >> diff;
+        if i < ri {
+            a.swap(ri as usize, i as usize);
+        }
     }
+}
 
-    pow
+/// This performs butterfly arithmetic with two `G` array
+fn butterfly_arithmetic<G: Group>(
+    left: &mut [G],
+    right: &mut [G],
+    twiddle_chunk: usize,
+    twiddles: &[G::Scalar],
+) {
+    // case when twiddle factor is one
+    let t = right[0];
+    right[0] = left[0];
+    left[0].group_add(&t);
+    right[0].group_sub(&t);
+
+    left.iter_mut()
+        .zip(right.iter_mut())
+        .enumerate()
+        .skip(1)
+        .for_each(|(i, (a, b))| {
+            let mut t = *b;
+            t.group_scale(&twiddles[i * twiddle_chunk]);
+            *b = *a;
+            a.group_add(&t);
+            b.group_sub(&t);
+        });
 }
 
 /// Returns coefficients of an n - 1 degree polynomial given a set of n points

--- a/halo2_proofs/src/multicore.rs
+++ b/halo2_proofs/src/multicore.rs
@@ -3,3 +3,14 @@
 //! be extended in the future to allow for various parallelism strategies.
 
 pub use rayon::{current_num_threads, scope, Scope};
+
+pub(crate) fn log_threads() -> u32 {
+    let num_threads = current_num_threads();
+    assert!(num_threads > 0);
+    let mut pow = 0;
+    while (1 << (pow + 1)) <= num_threads {
+        pow += 1;
+    }
+
+    pow
+}

--- a/halo2_proofs/src/multicore.rs
+++ b/halo2_proofs/src/multicore.rs
@@ -7,10 +7,5 @@ pub use rayon::{current_num_threads, scope, Scope};
 pub(crate) fn log_threads() -> u32 {
     let num_threads = current_num_threads();
     assert!(num_threads > 0);
-    let mut pow = 0;
-    while (1 << (pow + 1)) <= num_threads {
-        pow += 1;
-    }
-
-    pow
+    usize::BITS - 1 - num_threads.leading_zeros()
 }

--- a/halo2_proofs/src/poly/domain.rs
+++ b/halo2_proofs/src/poly/domain.rs
@@ -372,7 +372,8 @@ impl<G: Group> EvaluationDomain<G> {
     }
 
     /// Get the divisor used for inverse fft.
-    pub fn get_divisor(&self) -> G::Scalar {
+    #[cfg(test)]
+    pub(crate) fn get_divisor(&self) -> G::Scalar {
         self.ifft_divisor
     }
 
@@ -472,8 +473,8 @@ pub struct PinnedEvaluationDomain<'a, G: Group> {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use super::*;
-    use crate::arithmetic::*;
+    use super::{EvaluationDomain, Field, FieldExt, Rotation};
+    use crate::arithmetic::{eval_polynomial, lagrange_interpolate};
     use crate::pasta::pallas::Scalar;
     use rand_core::OsRng;
 

--- a/halo2_proofs/src/poly/domain.rs
+++ b/halo2_proofs/src/poly/domain.rs
@@ -371,6 +371,11 @@ impl<G: Group> EvaluationDomain<G> {
         self.extended_omega
     }
 
+    /// Get the divisor used for inverse fft.
+    pub fn get_divisor(&self) -> G::Scalar {
+        self.ifft_divisor
+    }
+
     /// Multiplies a value by some power of $\omega$, essentially rotating over
     /// the domain.
     pub fn rotate_omega(&self, value: G::Scalar, rotation: Rotation) -> G::Scalar {


### PR DESCRIPTION
# Opt fft

## FFT
| k |  default  | optimize |
| ---- | ---- | ---- |
| 3 | 639.86 ns 642.98 ns 646.28 ns | 639.97 ns 644.09 ns 648.20 ns |
| 4 | 13.713 us 14.033 us 14.386 us | 1.4760 us 1.4853 us 1.4950 us |
| 5 | 21.541 us 21.575 us 21.610 us | 3.2902 us 3.3092 us 3.3286 us |
| 6 | 29.259 us 29.594 us 30.018 us | 7.3762 us 7.3945 us 7.4133 us |
| 7 | 41.503 us 41.589 us 41.683 us | 16.666 us 16.724 us 16.784 us |
| 8 | 61.099 us 62.591 us 64.659 us | 39.766 us 40.486 us 41.447 us |
| 9 | 85.812 us 87.432 us 89.130 us | 82.304 us 83.100 us 84.396 us |
| 10 | 189.75 us 227.31 us 286.96 us | 143.56 us 144.84 us 146.33 us |
| 11 | 307.81 us 320.55 us 334.56 us | 260.60 us 262.47 us 264.41 us |
| 12 | 572.35 us 602.81 us 642.59 us | 516.65 us 522.51 us 527.84 us |
| 13 | 1.0706 ms 1.0997 ms 1.1378 ms | 990.55 us 1.0057 ms 1.0350 ms |
| 14 | 2.2858 ms 2.3534 ms 2.4349 ms | 2.0759 ms 2.1049 ms 2.1372 ms |
| 15 | 4.3920 ms 4.4207 ms 4.4544 ms | 4.1839 ms 4.2064 ms 4.2339 ms |
| 16 | 9.7456 ms 9.9426 ms 10.166 ms | 8.9873 ms 9.1112 ms 9.2438 ms |
| 17 | 21.843 ms 22.563 ms 23.441 ms | 19.496 ms 20.125 ms 20.996 ms |
| 18 | 48.491 ms 50.390 ms 52.815 ms | 44.283 ms 44.972 ms 45.690 ms |

## iFFT

| k |  default  | optimize |
| ---- | ---- | ---- |
3  | 10.892 us 11.390 us 11.899 us | 858.00 ns 862.05 ns 866.08 ns |
4  | 21.124 us 21.426 us 21.792 us | 1.8727 us 1.8796 us 1.8872 us |
5  | 26.511 us 26.724 us 26.978 us | 4.1678 us 4.1850 us 4.2019 us |
6  | 43.917 us 44.081 us 44.268 us | 9.0844 us 9.1195 us 9.1559 us |
7  | 56.390 us 56.661 us 56.933 us | 20.195 us 20.262 us 20.331 us |
8  | 71.472 us 71.831 us 72.229 us | 44.580 us 44.714 us 44.860 us |
9  | 119.10 us 119.37 us 119.68 us | 104.08 us 106.65 us 110.27 us |
10 | 253.42 us 256.95 us 260.37 us | 227.34 us 229.65 us 231.95 us |
11 | 538.85 us 560.10 us 591.15 us | 487.18 us 495.59 us 506.46 us |
12 | 1.0643 ms 1.0856 ms 1.1143 ms | 1.0369 ms 1.0383 ms 1.0400 ms |
13 | 2.2433 ms 2.2986 ms 2.3693 ms | 2.3088 ms 2.3388 ms 2.3844 ms |
14 | 4.6715 ms 4.7023 ms 4.7342 ms | 4.6114 ms 4.6336 ms 4.6570 ms |
15 | 10.286 ms 10.387 ms 10.501 ms | 10.613 ms 10.680 ms 10.756 ms |
16 | 23.683 ms 24.087 ms 24.564 ms | 22.811 ms 23.327 ms 23.977 ms |
17 | 49.733 ms 50.217 ms 50.717 ms | 49.204 ms 49.846 ms 50.753 ms |
18 | 112.70 ms 115.17 ms 118.72 ms | 111.66 ms 113.32 ms 115.38 ms |