### PR TITLE
Stash/ifft optimization

### DIFF
--- a/halo2_proofs/src/arithmetic/fft.rs
+++ b/halo2_proofs/src/arithmetic/fft.rs
@@ -1,3 +1,4 @@
+use super::multicore::{self, log_threads, prelude::*};
 pub use pasta_curves::arithmetic::*;
 
 /// This performs serial butterfly arithmetic
@@ -7,39 +8,131 @@ pub(crate) fn serial_fft<G: Group>(a: &mut [G], n: usize, log_n: u32, twiddles: 
     for _ in 0..log_n {
         a.chunks_mut(chunk).for_each(|coeffs| {
             let (left, right) = coeffs.split_at_mut(chunk / 2);
-            butterfly_arithmetic(left, right, twiddle_chunk, twiddles)
+            serial_butterfly_arithmetic(left, right, twiddle_chunk, twiddles)
         });
         chunk *= 2;
         twiddle_chunk /= 2;
     }
 }
 
-/// This perform recursive butterfly arithmetic
+/// This performs recursive butterfly arithmetic
 pub(crate) fn parallel_fft<G: Group>(
-    a: &mut [G],
+    left: &mut [G],
+    right: &mut [G],
     n: usize,
     twiddle_chunk: usize,
     twiddles: &[G::Scalar],
 ) {
-    if n == 2 {
-        let t = a[1];
-        a[1] = a[0];
-        a[0].group_add(&t);
-        a[1].group_sub(&t);
+    if n == 8 {
+        left.chunks_mut(2)
+            .zip(right.chunks_mut(2))
+            .for_each(|(a, b)| self_swap_arithmetic(a, b, 0, 1));
+        let (a, b) = left.split_at_mut(n / 2);
+        let (c, d) = right.split_at_mut(n / 2);
+        let (a1, a2) = a.split_at_mut(n / 4);
+        let (b1, b2) = b.split_at_mut(n / 4);
+        let (c1, c2) = c.split_at_mut(n / 4);
+        let (d1, d2) = d.split_at_mut(n / 4);
+        double_butterfly_arithmetic(a1, a2, b1, b2, twiddle_chunk * 2, twiddles);
+        double_butterfly_arithmetic(c1, c2, d1, d2, twiddle_chunk * 2, twiddles);
+        double_butterfly_arithmetic(a, b, c, d, twiddle_chunk, twiddles);
     } else {
-        let (left, right) = a.split_at_mut(n / 2);
+        let (a, b) = left.split_at_mut(n / 2);
+        let (c, d) = right.split_at_mut(n / 2);
         rayon::join(
-            || parallel_fft(left, n / 2, twiddle_chunk * 2, twiddles),
-            || parallel_fft(right, n / 2, twiddle_chunk * 2, twiddles),
+            || parallel_fft(a, b, n / 2, twiddle_chunk * 2, twiddles),
+            || parallel_fft(c, d, n / 2, twiddle_chunk * 2, twiddles),
         );
-
-        butterfly_arithmetic(left, right, twiddle_chunk, twiddles)
+        double_butterfly_arithmetic(a, b, c, d, twiddle_chunk, twiddles);
     }
+}
+
+/// This performs butterfly arithmetic with two `G` array
+pub(crate) fn serial_butterfly_arithmetic<G: Group>(
+    left: &mut [G],
+    right: &mut [G],
+    twiddle_chunk: usize,
+    twiddles: &[G::Scalar],
+) {
+    // case when twiddle factor is one
+    swap_arithmetic(&mut left[0], &mut right[0]);
+
+    left.iter_mut()
+        .zip(right.iter_mut())
+        .enumerate()
+        .skip(1)
+        .for_each(|(i, (a, b))| swap_arithmetic_with_twiddle(a, b, &twiddles[i * twiddle_chunk]));
+}
+
+/// This performs butterfly arithmetic with two `G` array
+pub(crate) fn parallel_butterfly_arithmetic<G: Group>(
+    left: &mut [G],
+    right: &mut [G],
+    twiddle_chunk: usize,
+    twiddles: &[G::Scalar],
+) {
+    // case when twiddle factor is one
+    swap_arithmetic(&mut left[0], &mut right[0]);
+
+    left.par_iter_mut()
+        .zip(right.par_iter_mut())
+        .enumerate()
+        .skip(1)
+        .for_each(|(i, (a, b))| swap_arithmetic_with_twiddle(a, b, &twiddles[i * twiddle_chunk]));
+}
+
+/// This performs butterfly arithmetic with two `G` array and divisor
+pub(crate) fn parallel_butterfly_arithmetic_with_divisor<G: Group>(
+    left: &mut [G],
+    right: &mut [G],
+    twiddle_chunk: usize,
+    twiddles: &[G::Scalar],
+    divisor: G::Scalar,
+) {
+    // case when twiddle factor is one
+    swap_arithmetic(&mut left[0], &mut right[0]);
+    left[0].group_scale(&divisor);
+    right[0].group_scale(&divisor);
+
+    left.par_iter_mut()
+        .zip(right.par_iter_mut())
+        .enumerate()
+        .skip(1)
+        .for_each(|(i, (a, b))| {
+            swap_arithmetic_with_twiddle(a, b, &twiddles[i * twiddle_chunk]);
+            a.group_scale(&divisor);
+            b.group_scale(&divisor)
+        });
+}
+
+/// This performs butterfly arithmetic with four `G` array
+pub(crate) fn double_butterfly_arithmetic<G: Group>(
+    a: &mut [G],
+    b: &mut [G],
+    c: &mut [G],
+    d: &mut [G],
+    twiddle_chunk: usize,
+    twiddles: &[G::Scalar],
+) {
+    // case when twiddle factor is one
+    swap_arithmetic(&mut a[0], &mut b[0]);
+    swap_arithmetic(&mut c[0], &mut d[0]);
+
+    a.iter_mut()
+        .zip(b.iter_mut())
+        .zip(c.iter_mut())
+        .zip(d.iter_mut())
+        .enumerate()
+        .skip(1)
+        .for_each(|(i, (((a, b), c), d))| {
+            swap_arithmetic_with_twiddle(a, b, &twiddles[i * twiddle_chunk]);
+            swap_arithmetic_with_twiddle(c, d, &twiddles[i * twiddle_chunk]);
+        });
 }
 
 /// This performs bit reverse permutation over `[G]`
 pub(crate) fn swap_bit_reverse<G: Group>(a: &mut [G], n: usize, log_n: u32) {
-    assert!(log_n <= 64);
+    // sort by bit reverse
     let diff = 64 - log_n;
     for i in 0..n as u64 {
         let ri = i.reverse_bits() >> diff;
@@ -49,30 +142,38 @@ pub(crate) fn swap_bit_reverse<G: Group>(a: &mut [G], n: usize, log_n: u32) {
     }
 }
 
-/// This performs butterfly arithmetic with two `G` array
-fn butterfly_arithmetic<G: Group>(
-    left: &mut [G],
-    right: &mut [G],
-    twiddle_chunk: usize,
-    twiddles: &[G::Scalar],
-) {
-    // case when twiddle factor is one
-    let t = right[0];
-    right[0] = left[0];
-    left[0].group_add(&t);
-    right[0].group_sub(&t);
+/// This performs permutation and butterfly arithmetic without twiddle for `G`
+pub(crate) fn swap_arithmetic<G: Group>(a: &mut G, b: &mut G) {
+    let t = *b;
+    *b = *a;
+    a.group_add(&t);
+    b.group_sub(&t);
+}
 
-    left.iter_mut()
-        .zip(right.iter_mut())
-        .enumerate()
-        .skip(1)
-        .for_each(|(i, (a, b))| {
-            let mut t = *b;
-            t.group_scale(&twiddles[i * twiddle_chunk]);
-            *b = *a;
-            a.group_add(&t);
-            b.group_sub(&t);
-        });
+/// This performs permutation and butterfly arithmetic twiddle for `G`
+pub(crate) fn swap_arithmetic_with_twiddle<G: Group>(a: &mut G, b: &mut G, twiddle: &G::Scalar) {
+    let mut t = *b;
+    t.group_scale(twiddle);
+    *b = *a;
+    a.group_add(&t);
+    b.group_sub(&t);
+}
+
+/// This performs permutation and butterfly arithmetic without twiddle for `[G]`
+pub(crate) fn self_swap_arithmetic<G: Group>(
+    a: &mut [G],
+    b: &mut [G],
+    former: usize,
+    latter: usize,
+) {
+    let t = a[latter];
+    a[latter] = a[former];
+    a[former].group_add(&t);
+    a[latter].group_sub(&t);
+    let t = b[latter];
+    b[latter] = b[former];
+    b[former].group_add(&t);
+    b[latter].group_sub(&t);
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Bench
## Fft

| k | default | optimize |
| ---- | ---- | ---- |
| 3  |  8.6142 us 8.7320 us 8.8689 us | 11.230 us 11.737 us 12.226 us |
| 4  |  12.216 us 12.518 us 12.781 us | 16.167 us 16.317 us 16.504 us |
| 5  |  17.907 us 18.075 us 18.248 us | 27.027 us 27.250 us 27.513 us |
| 6  |  21.525 us 21.752 us 22.010 us | 33.891 us 33.986 us 34.100 us |
| 7  |  32.153 us 32.555 us 33.005 us | 43.276 us 43.629 us 44.148 us |
| 8  |  55.390 us 56.248 us 57.279 us | 60.931 us 61.034 us 61.144 us |
| 9  |  117.99 us 119.50 us 121.12 us | 98.819 us 98.957 us 99.103 us |
| 10 |  225.96 us 230.78 us 236.58 us | 204.90 us 205.22 us 205.59 us |
| 11 |  456.56 us 462.97 us 469.76 us | 393.68 us 394.72 us 395.97 us |
| 12 |  990.68 us 1.0041 ms 1.0180 ms | 804.23 us 806.61 us 809.81 us |
| 13 |  2.0845 ms 2.1082 ms 2.1342 ms | 1.6780 ms 1.6823 ms 1.6867 ms |
| 14 |  4.6226 ms 4.6824 ms 4.7474 ms | 3.6270 ms 3.6390 ms 3.6516 ms |
| 15 |  9.8348 ms 9.9397 ms 10.050 ms | 7.7459 ms 7.7745 ms 7.8162 ms |
| 16 |  22.045 ms 22.281 ms 22.529 ms | 16.737 ms 16.785 ms 16.838 ms |
| 17 |  46.408 ms 46.923 ms 47.523 ms | 35.236 ms 35.386 ms 35.540 ms |
| 18 |  101.64 ms 102.47 ms 103.32 ms | 71.808 ms 72.333 ms 72.864 ms |

## iFft

| k | default | optimize |
| ---- | ---- | ---- |
| 3  | 15.906 us 16.232 us 16.676 us | 10.271 us 10.816 us 11.347 us |
| 4  | 23.633 us 24.137 us 24.568 us | 19.606 us 19.902 us 20.150 us |
| 5  | 29.275 us 29.674 us 30.097 us | 25.865 us 25.916 us 25.969 us |
| 6  | 35.161 us 35.570 us 36.032 us | 33.055 us 33.166 us 33.284 us |
| 7  | 49.167 us 49.667 us 50.194 us | 40.653 us 40.848 us 41.088 us |
| 8  | 72.378 us 73.080 us 73.795 us | 58.122 us 58.309 us 58.510 us |
| 9  | 127.11 us 129.10 us 131.32 us | 94.781 us 94.909 us 95.061 us |
| 10 | 264.60 us 268.29 us 272.14 us | 198.37 us 198.92 us 199.50 us |
| 11 | 531.11 us 538.95 us 547.58 us | 379.75 us 381.34 us 383.52 us |
| 12 | 1.0617 ms 1.0768 ms 1.0931 ms | 786.08 us 787.40 us 788.86 us |
| 13 | 2.3718 ms 2.4091 ms 2.4506 ms | 1.6333 ms 1.6368 ms 1.6408 ms |
| 14 | 5.1134 ms 5.1716 ms 5.2331 ms | 3.7590 ms 3.7686 ms 3.7793 ms |
| 15 | 11.179 ms 11.294 ms 11.413 ms | 7.5309 ms 7.5854 ms 7.6419 ms |
| 16 | 23.664 ms 23.895 ms 24.134 ms | 16.215 ms 16.277 ms 16.348 ms |
| 17 | 53.265 ms 53.823 ms 54.415 ms | 34.193 ms 34.371 ms 34.595 ms |
| 18 | 111.49 ms 112.73 ms 114.20 ms | 81.539 ms 82.120 ms 82.681 ms |